### PR TITLE
ochrana proti opětovnému nastavení hlaviček

### DIFF
--- a/src/DI/HeadersSetup.php
+++ b/src/DI/HeadersSetup.php
@@ -4,6 +4,10 @@ namespace Pd\SecurityHeaders\DI;
 
 final class HeadersSetup implements IOnPresenterListener
 {
+	/**
+	 * @var bool
+	 */
+	private $headersSent = FALSE;
 
 	/**
 	 * @var IHeadersFactory
@@ -28,9 +32,15 @@ final class HeadersSetup implements IOnPresenterListener
 		if (\PHP_SAPI === 'cli') {
 			return;
 		}
+		
+		if ($this->headersSent) {
+			return;
+		}
 
 		foreach ($this->factory->getHeaders() as $header) {
 			$this->response->addHeader($header->getName(), $header->getValue());
 		}
+		
+		$this->headersSent = TRUE;
 	}
 }


### PR DESCRIPTION
Řeší chybu kdy se znovu nastavují hlavičky po vyrenderování nějakého obsahu. Může nastat například při chybě v šabloně, která inicializuje ErrorPresenter, při které se znovu volá onPresenter